### PR TITLE
Update news views for "All news" pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository can be cloned on top of any Drupal installation but it is easier
 borg list --last 9 fsicos.lunarc.lu.se:/disk/data/bbserver/repos/fsicos2.lunarc.lu.se/drupal/default/
 ```
 
-and then extract one of them
+and then extract one of them:
 
 ```
 borg extract fsicos.lunarc.lu.se:/disk/data/bbserver/repos/fsicos2.lunarc.lu.se/drupal/default/::cp-2021-04-01T03:11:29
@@ -27,3 +27,5 @@ docker compose up -d
 ```
 
 Once the container is running, you must run the `composer update` command inside the Drupal container. Additionally, you must run `chown -R www-data:www-data /var/www/html/sites/default/files` inside the Drupal container in order to enable file uploading.
+
+Note that by using a production backup, **all of the production configuration settings are present**, including SMTP settings for sending emails (e.g., scheduled emails from webforms). Ensure you disable this setting if you are creating a development environment (Admin -> Configuration -> System -> SMTP Authentication Support).

--- a/modules/cp_events/cp_events.libraries.yml
+++ b/modules/cp_events/cp_events.libraries.yml
@@ -1,0 +1,9 @@
+style:
+  css:
+    theme:
+      css/cp-events.css: {}
+
+script:
+  dependencies:
+    - core/jquery
+    - core/jquery.once

--- a/modules/cp_events/cp_events.libraries.yml
+++ b/modules/cp_events/cp_events.libraries.yml
@@ -2,8 +2,3 @@ style:
   css:
     theme:
       css/cp-events.css: {}
-
-script:
-  dependencies:
-    - core/jquery
-    - core/jquery.once

--- a/modules/cp_events/cp_events.module
+++ b/modules/cp_events/cp_events.module
@@ -1,6 +1,16 @@
 <?php
 
 /**
+ * Implements hook_preprocess_views_view().
+ */
+
+function cp_events_preprocess_views_view(&$vars) {
+  if ($vars['view']->storage->id() === 'news') {
+    $vars['#attached']['library'][] = 'cp_events/style';
+  }
+}
+
+/**
  * Implements hook_theme().
  */
 function cp_events_theme() {

--- a/modules/cp_events/css/cp-events.css
+++ b/modules/cp_events/css/cp-events.css
@@ -15,7 +15,7 @@
 .views-two-column {
   margin-top: 2em;
   margin-bottom: 2em;
-  border-bottom: solid 1px var(--icos-grey-50);
+  border-bottom: solid 1px #d6d6d6;
   padding-bottom: 2em;
   
   .views-field {
@@ -33,7 +33,7 @@
 
 @media all and (max-width: 799px) {
   .views-two-column .views-field {
-    margin-left: auto;
+    margin-left: 0;
     max-width: 100%;
   }
 

--- a/modules/cp_events/css/cp-events.css
+++ b/modules/cp_events/css/cp-events.css
@@ -1,6 +1,6 @@
 /* Latest news block and view */
-.sidebar-second .view-news .views-field-field-image img,
-.sidebar-second .view-news .views-field-field-cp-event-picture img {
+.sidebar .view-news .views-field-field-image img,
+.sidebar .view-news .views-field-field-cp-event-picture img {
   float: right;
   margin-left: 2rem;
 }

--- a/modules/cp_events/css/cp-events.css
+++ b/modules/cp_events/css/cp-events.css
@@ -1,0 +1,54 @@
+
+/* Latest news block and view */
+.view-display-id-block_1.view-news .views-field-field-image img,
+.view-display-id-block_1.view-news .views-field-field-cp-event-picture img {
+  float: right;
+  margin-left: 2rem;
+}
+
+/* News block/pages */
+.view-news:not(.view-display-id-block_1) .view-content .float-view {
+  margin-top: 1em;
+  
+  &::after {
+    width: 100%;
+    border-bottom: solid 2px;
+    border-image: linear-gradient(90deg, var(--icos-magenta) 26.25%, var(--icos-cyan) 26.25%) 100% 1;
+    padding-bottom: 1em;
+    margin-bottom: 1em;
+  }
+
+  h3 {
+    margin: 0;
+  }
+
+  & > *, .views-field-body {
+    margin-left: 27.5%; /* 25% for image, 2.5% for white space */
+    max-width: 70%;
+  }
+
+  .views-field-field-image, .views-field-field-cp-event-picture {
+    float: left;
+    min-height: 20vh;
+    width: 25%;
+    margin-left: 0;
+
+    img {
+      max-height: 20vh;
+      object-fit: contain;
+    }
+  }
+
+}
+
+@media all and (max-width: 799px) {
+  .view-news:not(.view-display-id-block_1) .view-content .float-view > *, .float-view .views-field-body{
+    margin-left: auto;
+    max-width: 100%;
+  }
+
+  .view-news:not(.view-display-id-block_1) .view-content .float-view .views-field-field-image,
+  .view-news:not(.view-display-id-block_1) .view-content .float-view .views-field-field-cp-event-picture {
+    display: none;
+  }
+}

--- a/modules/cp_events/css/cp-events.css
+++ b/modules/cp_events/css/cp-events.css
@@ -1,69 +1,43 @@
-/* Latest news block and view */
-.sidebar .view-news .views-field-field-image img,
-.sidebar .view-news .views-field-field-cp-event-picture img {
+/* Latest news block and view use .sidebar-list
+  .sidebar-list forces images to float right, with a left margin. */
+.sidebar-list img {
   float: right;
   margin-left: 2rem;
 }
 
-/* News block/pages */
-#content .view-news .view-content .float-view {
-  margin-top: 1em;
+/* News pages use the .views-two-column
+
+  .views-two-column should be applied to each row in an unformatted list.
+
+  .float-left should be applied to the field you would like to have on the left 
+    (which will responsively disappear at small page widths).
+*/
+.views-two-column {
+  margin-top: 2em;
+  margin-bottom: 2em;
+  border-bottom: solid 1px var(--icos-grey-50);
+  padding-bottom: 2em;
   
-  &::after {
-    width: 100%;
-    border-bottom: solid 2px;
-    border-image: linear-gradient(90deg, var(--icos-magenta) 26.25%, var(--icos-cyan) 26.25%) 100% 1;
-    padding-bottom: 1em;
-    margin-bottom: 1em;
-  }
-
-  h3 {
-    margin: 0;
-  }
-
-  & > *, .views-field-body {
+  .views-field {
     margin-left: 27.5%; /* 20% for image, 2.5% for white space */
     max-width: 70%;
   }
 
-  .views-field-field-image, .views-field-field-cp-event-picture {
+  .views-field.float-left {
     float: left;
-    height: auto;
     width: 25%;
-    aspect-ratio: auto;
     margin-left: 0;
-    overflow: hidden;
-
-    .field-content, a {
-      height: 100%;
-      width: 100%;
-    }
-
-    a {
-      display: flex;
-      align-items: start;
-      justify-content: center;
-    }
-
-    img {
-      object-fit: cover;
-      object-position: top;
-      max-height: unset;
-      max-width: 100%;
-    }
   }
 
 }
 
 @media all and (max-width: 799px) {
-  #content .view-news .view-content .float-view > *, 
-  #content .view-news .view-content .float-view .views-field-body {
+  .views-two-column .views-field {
     margin-left: auto;
     max-width: 100%;
   }
 
-  #content .view-news .view-content .float-view .views-field-field-image,
-  #content .view-news .view-content .float-view .views-field-field-cp-event-picture {
+  .views-two-column .views-field.float-left {
     display: none;
   }
 }

--- a/modules/cp_events/css/cp-events.css
+++ b/modules/cp_events/css/cp-events.css
@@ -1,13 +1,12 @@
-
 /* Latest news block and view */
-.view-display-id-block_1.view-news .views-field-field-image img,
-.view-display-id-block_1.view-news .views-field-field-cp-event-picture img {
+.sidebar-second .view-news .views-field-field-image img,
+.sidebar-second .view-news .views-field-field-cp-event-picture img {
   float: right;
   margin-left: 2rem;
 }
 
 /* News block/pages */
-.view-news:not(.view-display-id-block_1) .view-content .float-view {
+#content .view-news .view-content .float-view {
   margin-top: 1em;
   
   &::after {
@@ -23,32 +22,48 @@
   }
 
   & > *, .views-field-body {
-    margin-left: 27.5%; /* 25% for image, 2.5% for white space */
+    margin-left: 27.5%; /* 20% for image, 2.5% for white space */
     max-width: 70%;
   }
 
   .views-field-field-image, .views-field-field-cp-event-picture {
     float: left;
-    min-height: 20vh;
+    height: auto;
     width: 25%;
+    aspect-ratio: auto;
     margin-left: 0;
+    overflow: hidden;
+
+    .field-content, a {
+      height: 100%;
+      width: 100%;
+    }
+
+    a {
+      display: flex;
+      align-items: start;
+      justify-content: center;
+    }
 
     img {
-      max-height: 20vh;
-      object-fit: contain;
+      object-fit: cover;
+      object-position: top;
+      max-height: unset;
+      max-width: 100%;
     }
   }
 
 }
 
 @media all and (max-width: 799px) {
-  .view-news:not(.view-display-id-block_1) .view-content .float-view > *, .float-view .views-field-body{
+  #content .view-news .view-content .float-view > *, 
+  #content .view-news .view-content .float-view .views-field-body {
     margin-left: auto;
     max-width: 100%;
   }
 
-  .view-news:not(.view-display-id-block_1) .view-content .float-view .views-field-field-image,
-  .view-news:not(.view-display-id-block_1) .view-content .float-view .views-field-field-cp-event-picture {
+  #content .view-news .view-content .float-view .views-field-field-image,
+  #content .view-news .view-content .float-view .views-field-field-cp-event-picture {
     display: none;
   }
 }

--- a/themes/cp_theme_d8/css/main.css
+++ b/themes/cp_theme_d8/css/main.css
@@ -76,12 +76,6 @@ iframe {
   }
 }
 
-.block-views .view-news .views-field.views-field-field-image img,
-.views-field-field-cp-event-picture img {
-  float: right;
-  margin-left: 2rem;
-}
-
 .page-title {
   font-weight: bold;
   font-size: 2.285rem;


### PR DESCRIPTION
Updating the `cp_events` module to allow for a better layout on news pages (e.g. [www.icos-cp.eu/news](https://www.icos-cp.eu/news)).

Removes some `cp_events` specific CSS from `main.css` to the `cp-events.css ` file.

Requires administrative changes in order to actually apply the layout changes, detailed in Asana.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208362399676937