### PR TITLE
[icos] Add delay to menu hover and allow keyboard menu expansion

### DIFF
--- a/themes/cp_theme_d8/css/menu.css
+++ b/themes/cp_theme_d8/css/menu.css
@@ -170,7 +170,8 @@
     transition: border 0.1s ease-out;
   }
 
-  #cp_theme_d8_menu li:hover {
+  #cp_theme_d8_menu li:hover,
+  #cp_theme_d8_menu li:has(a:focus) {
     background-color: var(--icos-grey-90);
   }
 
@@ -198,7 +199,8 @@
     flex-wrap: wrap;
   }
 
-  #cp_theme_d8_menu .is_topnode:hover > ul {
+  #cp_theme_d8_menu .is_topnode:hover > ul,
+  #cp_theme_d8_menu .is_topnode:has(a:focus) > ul {
     visibility: visible;
     z-index: 11;
     transition: visibility 0s 0.4s;

--- a/themes/cp_theme_d8/css/menu.css
+++ b/themes/cp_theme_d8/css/menu.css
@@ -143,7 +143,7 @@
   #cp_theme_d8_menu li {
     list-style: none;
     cursor: pointer;
-    transition: background-color 0.1s ease-out;
+    transition: background-color 0.4s ease-out;
   }
 
   #cp_theme_d8_menu li li {
@@ -192,7 +192,7 @@
     padding: 1rem 1rem 1.5rem;
     background-color: var(--icos-grey-90);
     z-index: 10;
-    transition: visibility 0.1s ease-out;
+    transition: visibility 0s 0.45s;
     margin: 0 auto;
     box-shadow: 0px 1px 1px #333;
     flex-wrap: wrap;
@@ -200,6 +200,8 @@
 
   #cp_theme_d8_menu .is_topnode:hover > ul {
     visibility: visible;
+    z-index: 11;
+    transition: visibility 0s 0.4s;
   }
 
   #cp_theme_d8_menu li li a {

--- a/themes/cp_theme_d8/css/menu.css
+++ b/themes/cp_theme_d8/css/menu.css
@@ -186,24 +186,38 @@
   #cp_theme_d8_menu .is_topnode > ul {
     max-width: 1100px;
     visibility: hidden;
+    max-height: 0;
     position: absolute;
     left: 50px;
     right: 50px;
     justify-content: flex-start;
-    padding: 1rem 1rem 1.5rem;
+    padding: 0 1rem;
     background-color: var(--icos-grey-90);
     z-index: 10;
-    transition: visibility 0s 0.45s;
+    transition: visibility 0s 0.6s, max-height ease-out 0.3s 0.3s, padding-top 0.1s 0.4s, padding-bottom 0.1s 0.4s; /* exit hover transitions */
     margin: 0 auto;
     box-shadow: 0px 1px 1px #333;
     flex-wrap: wrap;
+    overflow: hidden;
   }
 
   #cp_theme_d8_menu .is_topnode:hover > ul,
   #cp_theme_d8_menu .is_topnode:has(a:focus) > ul {
     visibility: visible;
     z-index: 11;
-    transition: visibility 0s 0.4s;
+    max-height: 650px;
+    padding: 1rem 1rem 1.5rem;
+    transition: visibility 0s 0.3s, max-height ease-in 0.3s 0.3s, padding-top 0.1s 0.3s, padding-bottom 0.1s 0.3s; /* enter hover transitions*/
+  }
+
+  #cp_theme_d8_menu .is_topnode ul li {
+    opacity: 0;
+    transition: opacity linear 0.2s 0.3s;
+  }
+
+  #cp_theme_d8_menu .is_topnode:hover ul li {
+    opacity: 1;
+    transition: opacity linear 0.2s 0.3s;
   }
 
   #cp_theme_d8_menu li li a {


### PR DESCRIPTION
Improve user experience by delaying opening of menu so that briefly hovering over a menu item does not take up the entire screen on small displays.

Increases general delay from 0.1s to 0.4s; adds additional delay for "disappearing" to ensure flickering does not occur, and increases z-index on hover so hovered tab always appears on top.

Also adds rules to allow keyboard focus to expand menu. (Note that for testing, the "admin" interface messes with tab order somehow and the menu navigation links are not focusable; I am not sure why, but it works for non-logged in users just fine.)

The keyboard focus could use some work; right now if you hover over something else with a menu open via keyboard focus, the menu opens "twice", and it can be difficult to close the menu via keyboard only. But it is still preferable for accessibility to allow keyboard focus to open the menu, I think.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208361819652425