### PR TITLE
Add other resolution videos to front page video

### DIFF
--- a/modules/custom/cp_layouts/src/Plugin/Layout/VideoLayout.php
+++ b/modules/custom/cp_layouts/src/Plugin/Layout/VideoLayout.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\cp_layouts\Plugin\Layout;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Layout\LayoutDefault;
+
+/**
+ * Layout class providing configurable video source URLs at three resolutions.
+ */
+class VideoLayout extends LayoutDefault {
+
+  public function defaultConfiguration() {
+    return parent::defaultConfiguration() + [
+      'video_url_1080p' => '',
+      'video_url_720p' => '',
+      'video_url_480p' => '',
+    ];
+  }
+
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+    $form['video_url_1080p'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Video URL (1080p)'),
+      '#default_value' => $this->configuration['video_url_1080p'],
+    ];
+    $form['video_url_720p'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Video URL (720p)'),
+      '#default_value' => $this->configuration['video_url_720p'],
+    ];
+    $form['video_url_480p'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Video URL (480p)'),
+      '#default_value' => $this->configuration['video_url_480p'],
+    ];
+    return $form;
+  }
+
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    parent::submitConfigurationForm($form, $form_state);
+    $this->configuration['video_url_1080p'] = $form_state->getValue('video_url_1080p');
+    $this->configuration['video_url_720p'] = $form_state->getValue('video_url_720p');
+    $this->configuration['video_url_480p'] = $form_state->getValue('video_url_480p');
+  }
+
+}

--- a/themes/cp_theme_d10/cp_theme_d10.layouts.yml
+++ b/themes/cp_theme_d10/cp_theme_d10.layouts.yml
@@ -114,6 +114,7 @@ lgray_two_col_layout:
 video_layout:
   label: 'Video background'
   category: 'CP'
+  class: 'Drupal\cp_layouts\Plugin\Layout\VideoLayout'
   template: 'layouts/video'
   library: cp_layouts/video
   regions:

--- a/themes/cp_theme_d10/css/frontpage.css
+++ b/themes/cp_theme_d10/css/frontpage.css
@@ -224,6 +224,14 @@
   }
 }
 
+.page .page-content .layout.layout--video {
+  background: url('/home-image');
+  background-position-x: center;
+  background-position-y: bottom;
+  background-size: cover;
+  background-repeat: no-repeat;
+}
+
 /* Smaller than Bootstrap M breakpoint */
 @media all and (max-width: 767.98px) {
   .space-top {

--- a/themes/cp_theme_d10/css/frontpage.css
+++ b/themes/cp_theme_d10/css/frontpage.css
@@ -243,11 +243,6 @@
   }
 
   .page .page-content .layout.layout--video {
-    background: url('/home-image');
-    background-position-x: center;
-    background-position-y: bottom;
-    background-repeat: no-repeat;
-
     .text-overlay {
       min-height: 420px;
       height: unset;

--- a/themes/cp_theme_d10/layouts/video.html.twig
+++ b/themes/cp_theme_d10/layouts/video.html.twig
@@ -27,11 +27,9 @@
   ]
 %}
 
-{%
-  set video_1080p = settings.video_url_1080p ?? "https://static.icos-cp.eu/videos/video1-1080p.mp4"
-  set video_720p = settings.video_url_720p ?? "https://static.icos-cp.eu/videos/video1-720p.mp4"
-  set video_480p = settings.video_url_480p ?? "https://static.icos-cp.eu/videos/video1-480p.mp4"
-%}
+{% set video_1080p = settings.video_url_1080p == "" ? "https://static.icos-cp.eu/videos/video1-1080p.mp4" : settings.video_url_1080p %}
+{% set video_720p = settings.video_url_720p == "" ? "https://static.icos-cp.eu/videos/video1-720p.mp4" : settings.video_url_720p %}
+{% set video_480p = settings.video_url_480p == "" ? "https://static.icos-cp.eu/videos/video1-480p.mp4" : settings.video_url_480p %}
 
 {% if content %}
   <div{{ attributes.addClass(classes) }}>

--- a/themes/cp_theme_d10/layouts/video.html.twig
+++ b/themes/cp_theme_d10/layouts/video.html.twig
@@ -30,7 +30,9 @@
 {% if content %}
   <div{{ attributes.addClass(classes) }}>
     <video autoplay disablepictureinpicture loop muted playsinline id="fp-video">
-      <source src="/home-video" type="video/mp4">
+      <source src="/home-video-1-1080" type="video/mp4" media="(width > 1280px)">
+      <source src="/home-video-1-720" type="video/mp4" media="(width > 854px)">
+      <source src="/home-video-1-480" type="video/mp4" media="(width > 767px)">
     </video>
     <div class="text-overlay position-relative">
       {% if content.text %}
@@ -43,7 +45,7 @@
       <button
         type="button"
         id="toggle-video"
-        class="btn btn-outline-light rounded-circle position-absolute d-flex justify-content-center align-items-center"
+        class="d-none btn btn-outline-light rounded-circle position-absolute justify-content-center align-items-center"
         style="bottom: 3rem; right: 3rem; height: 45px; width: 45px;"><i class="fas fa-pause"></i></button>
     </div>
   </div>
@@ -55,6 +57,8 @@
       const pauseIcon = button.children[0];
       const playIcon = document.createElement("i");
       playIcon.classList.add("fas", "fa-play");
+      button.classList.remove("d-none");
+      button.classList.add("d-flex");
 
       button.addEventListener("click", (event) => {
         if (video.paused) {
@@ -82,7 +86,11 @@
         button.appendChild(pauseIcon);
       }
     }
-
-    document.addEventListener("DOMContentLoaded", initVideoToggle);
+    const videoEl = document.getElementById("fp-video");
+    if (videoEl.readyState === 4) {
+      initVideoToggle();
+    } else {
+      videoEl.addEventListener("loadeddata", initVideoToggle);
+    }
   </script>
 {% endif %}

--- a/themes/cp_theme_d10/layouts/video.html.twig
+++ b/themes/cp_theme_d10/layouts/video.html.twig
@@ -27,12 +27,18 @@
   ]
 %}
 
+{%
+  set video_1080p = settings.video_url_1080p ?? "https://static.icos-cp.eu/videos/video1-1080p.mp4"
+  set video_720p = settings.video_url_720p ?? "https://static.icos-cp.eu/videos/video1-720p.mp4"
+  set video_480p = settings.video_url_480p ?? "https://static.icos-cp.eu/videos/video1-480p.mp4"
+%}
+
 {% if content %}
   <div{{ attributes.addClass(classes) }}>
     <video autoplay disablepictureinpicture loop muted playsinline id="fp-video">
-      <source src="/home-video-1-1080" type="video/mp4" media="(width > 1280px)">
-      <source src="/home-video-1-720" type="video/mp4" media="(width > 854px)">
-      <source src="/home-video-1-480" type="video/mp4" media="(width > 767px)">
+      <source src="{{ video_1080p }}" type="video/mp4" media="(width > 1280px)">
+      <source src="{{ video_720p }}" type="video/mp4" media="(width > 854px)">
+      <source src="{{ video_480p }}" type="video/mp4" media="(width > 767px)">
     </video>
     <div class="text-overlay position-relative">
       {% if content.text %}


### PR DESCRIPTION
Add support for multiple resolutions of video (480p, 720p, 1080p) depending on the browser width when page is loaded.

Includes ensuring video does not load at all on small screens, and that the "play/pause" button is hidden completely before a video is loaded. This should be much better for data usage and also user experience, at the cost of loading a slightly larger video on wide screens (7.5 MB vs. 4.5 MB).