### PR TITLE
[icos] Improve general appearance and add menu delay hover

### DIFF
--- a/themes/cp_theme_d10/css/menu.css
+++ b/themes/cp_theme_d10/css/menu.css
@@ -92,14 +92,6 @@
   }
 
   #cp_theme_d10_menu {
-    .top-node:hover .dropdown-menu,
-    .top-node:focus-within .dropdown-menu {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(0);
-      transition: visibility 0s 0.2s, opacity 0.2s ease-out 0.2s, transform 0.2s ease-out 0.2s;
-    }
-
     .top-node .dropdown-menu {
       display: flex;
       flex-wrap: nowrap;
@@ -113,7 +105,7 @@
       visibility: hidden;
       opacity: 0;
       transform: translateY(-6px);
-      transition: opacity 0.15s ease-in, visibility 0s 0.15s, transform 0.15s ease-in;
+      transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
 
       &>div {
         width: 19%;
@@ -128,7 +120,7 @@
       width: 100vw;
       background: white;
       box-shadow: rgba(0, 0, 0, 0.15) 0px 8px 16px 0px;
-      transition: height 0.15s ease-in 0.2s;
+      transition: height 0.2s ease-in-out;
     }
   }
 }

--- a/themes/cp_theme_d10/css/menu.css
+++ b/themes/cp_theme_d10/css/menu.css
@@ -96,7 +96,8 @@
     .top-node:focus-within .dropdown-menu {
       opacity: 1;
       visibility: visible;
-      transition: visibility 0s 0.5s, opacity 0.5s 0.5s;
+      transform: translateY(0);
+      transition: visibility 0s 0.2s, opacity 0.2s ease-out 0.2s, transform 0.2s ease-out 0.2s;
     }
 
     .top-node .dropdown-menu {
@@ -111,7 +112,8 @@
       border: 0;
       visibility: hidden;
       opacity: 0;
-      transition: visibility 0s 0.5s, opacity 0.5s 0s;
+      transform: translateY(-6px);
+      transition: opacity 0.15s ease-in, visibility 0s 0.15s, transform 0.15s ease-in;
 
       &>div {
         width: 19%;
@@ -124,10 +126,9 @@
       top: 38.5px;
       left: 0;
       width: 100vw;
-      height: 0px;
       background: white;
       box-shadow: rgba(0, 0, 0, 0.15) 0px 8px 16px 0px;
-      transition: height 0.5s 0.5s;
+      transition: height 0.15s ease-in 0.2s;
     }
   }
 }

--- a/themes/cp_theme_d10/css/menu.css
+++ b/themes/cp_theme_d10/css/menu.css
@@ -92,42 +92,16 @@
     .top-node:focus-within .dropdown-menu {
       display: flex;
       flex-wrap: nowrap;
-      visibility: visible;
-      max-height: 400px;
-      padding-top: 1rem !important;
-      padding-bottom: 1.5rem !important;
-      transition: visibility 0s 0.3s,
-        max-height 0.3s ease-out 0.3s,
-        padding-bottom 0.3s ease-out 0.3s,
-        padding-top 0.15s ease-out 0.3s;
-
-      &>div {
-        opacity: 1;
-        transition: opacity 0.3s linear 0.3s; 
-      }
     }
 
     .top-node .dropdown-menu {
-      display: flex;
-      flex-wrap: nowrap;
       left: 0;
-      overflow: clip;
       width: 100%;
       padding-left: 1rem;
       padding-right: 1rem;
-      padding-top: 0 !important;
-      padding-bottom: 0 !important;
-      visibility: hidden;
-      max-height: 0;
-      transition: visibility 0s 0.2s,
-        max-height 0.1s ease-out 0.1s,
-        padding-bottom 0.1s ease-out 0.1s,
-        padding-top 0.05s ease-out 0.15s;
 
       &>div {
         width: 19%;
-        opacity: 0;
-        transition: opacity 0.1s linear 0.1s; 
       }
     }
   }

--- a/themes/cp_theme_d10/css/menu.css
+++ b/themes/cp_theme_d10/css/menu.css
@@ -113,6 +113,7 @@
     }
 
     .menu-backdrop {
+      border-top: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color);
       z-index: 8;
       position: absolute;
       top: 38.5px;

--- a/themes/cp_theme_d10/css/menu.css
+++ b/themes/cp_theme_d10/css/menu.css
@@ -78,6 +78,10 @@
     .menu-level-3 {
       padding-left: 2rem;
     }
+
+    .menu-backdrop {
+      display: none;
+    }
   }
 }
 
@@ -103,6 +107,17 @@
       &>div {
         width: 19%;
       }
+    }
+
+    .menu-backdrop {
+      z-index: 8;
+      position: absolute;
+      top: 38.5px;
+      left: 0;
+      width: 100vw;
+      background: white;
+      box-shadow: rgba(0, 0, 0, 0.15) 0px 8px 16px 0px;
+      transition: height 0.2s 0.1s;
     }
   }
 

--- a/themes/cp_theme_d10/css/menu.css
+++ b/themes/cp_theme_d10/css/menu.css
@@ -103,6 +103,9 @@
       width: 100%;
       padding-left: 1rem;
       padding-right: 1rem;
+      background: none;
+      box-shadow: none;
+      border: 0;
 
       &>div {
         width: 19%;

--- a/themes/cp_theme_d10/css/menu.css
+++ b/themes/cp_theme_d10/css/menu.css
@@ -108,15 +108,6 @@
     }
 
     .top-node .dropdown-menu {
-      /*left: 0;
-      width: 100%;
-      padding-left: 1rem;
-      padding-right: 1rem;
-
-      &>div {
-        width: 19%;
-      } */
-
       display: flex;
       flex-wrap: nowrap;
       left: 0;

--- a/themes/cp_theme_d10/css/menu.css
+++ b/themes/cp_theme_d10/css/menu.css
@@ -94,11 +94,14 @@
   #cp_theme_d10_menu {
     .top-node:hover .dropdown-menu,
     .top-node:focus-within .dropdown-menu {
-      display: flex;
-      flex-wrap: nowrap;
+      opacity: 1;
+      visibility: visible;
+      transition: visibility 0s 0.5s, opacity 0.5s 0.5s;
     }
 
     .top-node .dropdown-menu {
+      display: flex;
+      flex-wrap: nowrap;
       left: 0;
       width: 100%;
       padding-left: 1rem;
@@ -106,6 +109,9 @@
       background: none;
       box-shadow: none;
       border: 0;
+      visibility: hidden;
+      opacity: 0;
+      transition: visibility 0s 0.5s, opacity 0.5s 0s;
 
       &>div {
         width: 19%;
@@ -118,12 +124,12 @@
       top: 38.5px;
       left: 0;
       width: 100vw;
+      height: 0px;
       background: white;
       box-shadow: rgba(0, 0, 0, 0.15) 0px 8px 16px 0px;
-      transition: height 0.2s 0.1s;
+      transition: height 0.5s 0.5s;
     }
   }
-
 }
 
 /* Bootstrap XXL breakpoint */

--- a/themes/cp_theme_d10/css/menu.css
+++ b/themes/cp_theme_d10/css/menu.css
@@ -96,7 +96,6 @@
 
     .top-node .dropdown-menu {
       left: 0;
-      box-shadow: none;
       width: 100%;
       padding-left: 1rem;
       padding-right: 1rem;

--- a/themes/cp_theme_d10/css/menu.css
+++ b/themes/cp_theme_d10/css/menu.css
@@ -91,17 +91,52 @@
     .top-node:hover .dropdown-menu,
     .top-node:focus-within .dropdown-menu {
       display: flex;
-      flex-wrap: none;
+      flex-wrap: nowrap;
+      visibility: visible;
+      max-height: 400px;
+      padding-top: 1rem !important;
+      padding-bottom: 1.5rem !important;
+      transition: visibility 0s 0.3s,
+        max-height 0.3s ease-out 0.3s,
+        padding-bottom 0.3s ease-out 0.3s,
+        padding-top 0.15s ease-out 0.3s;
+
+      &>div {
+        opacity: 1;
+        transition: opacity 0.3s linear 0.3s; 
+      }
     }
 
     .top-node .dropdown-menu {
-      left: 0;
+      /*left: 0;
       width: 100%;
       padding-left: 1rem;
       padding-right: 1rem;
 
       &>div {
         width: 19%;
+      } */
+
+      display: flex;
+      flex-wrap: nowrap;
+      left: 0;
+      overflow: clip;
+      width: 100%;
+      padding-left: 1rem;
+      padding-right: 1rem;
+      padding-top: 0 !important;
+      padding-bottom: 0 !important;
+      visibility: hidden;
+      max-height: 0;
+      transition: visibility 0s 0.2s,
+        max-height 0.1s ease-out 0.1s,
+        padding-bottom 0.1s ease-out 0.1s,
+        padding-top 0.05s ease-out 0.15s;
+
+      &>div {
+        width: 19%;
+        opacity: 0;
+        transition: opacity 0.1s linear 0.1s; 
       }
     }
   }
@@ -117,13 +152,6 @@
   }
 
   #cp_theme_d10_menu {
-    .top-node:hover .dropdown-menu,
-    .top-node:focus-within .dropdown-menu {
-      &>div {
-        width: 316px;
-      }
-    }
-
     .top-node .dropdown-menu {
       padding-left: calc((100% - 1400px)/2 + 1rem);
       padding-right: calc((100% - 1400px)/2 + 1rem);

--- a/themes/cp_theme_d10/css/page.css
+++ b/themes/cp_theme_d10/css/page.css
@@ -390,6 +390,8 @@ iframe {
 .cp_event #page .page-content,
 .system-404 .page-content,
 .system-403 .page-content,
+.path-user .page-content,
+.layout-builder-overrides-node-discard-changes .page-content,
 .cp-search-search-results-page #page .page-content {
   max-width: 70.5rem;
   margin-left: auto;
@@ -415,8 +417,7 @@ iframe {
 .node-add-page .page-content,
 .view-data-products-page-1 #page .page-content,
 .fluxes_volume .page-content .block:not(.block-system-main-block),
-.fluxes_volume .page-content .layout--normal,
-.path-user #page .page-content {
+.fluxes_volume .page-content .layout--normal {
   max-width: 1400px;
   margin-left: auto;
   margin-right: auto;

--- a/themes/cp_theme_d10/css/page.css
+++ b/themes/cp_theme_d10/css/page.css
@@ -383,6 +383,7 @@ iframe {
 
 /* "Narrow" pages -- all content narrow (70.5rem) */
 .fluxes_article .page-content,
+.path-webform .page-content,
 .webform #page .page-content,
 .entity-webform-canonical #page .page-content,
 .entity-webform-confirmation #page .page-content,

--- a/themes/cp_theme_d10/css/page.css
+++ b/themes/cp_theme_d10/css/page.css
@@ -448,7 +448,8 @@ iframe {
   .layout--threecol-section,
   .layout--twocol-section,
   .layout--colored-flex,
-  .layout--dark-blue-bot-left-two {
+  .layout--dark-blue-bot-left-two,
+  nav.tabs {
     max-width: 70.5rem;
     /* 1128px */
     margin-left: auto;
@@ -478,7 +479,8 @@ iframe {
   .layout--twocol-section,
   .layout--threecol-section,
   .layout--colored-flex,
-  .layout--dark-blue-bot-left-two {
+  .layout--dark-blue-bot-left-two,
+  nav.tabs {
     max-width: 1400px;
   }
 }

--- a/themes/cp_theme_d10/js/global.js
+++ b/themes/cp_theme_d10/js/global.js
@@ -27,34 +27,81 @@
         });
       });
       const menuBackdrop = document.querySelector(".menu-backdrop");
-      function whenEntered(topNode) {
+      if (!menuBackdrop) { return; }
+
+      let committedTopNode = null;
+      let dwellTimer = null;
+      let closeTimer = null;
+      let switchTimer = null;
+      const DWELL_TIME = 200;
+      const CLOSE_GRACE = 100;
+      const SWITCH_DELAY = 160;
+
+      function revealDropdown(topNode) {
+        if (committedTopNode !== topNode) { return; }
+        const dropdown = topNode.querySelector(':scope > .dropdown-menu');
+        if (dropdown) {
+          dropdown.style.visibility = 'visible';
+          dropdown.style.opacity = '1';
+          dropdown.style.transform = 'translateY(0)';
+        }
         let height = topNode.dataset.computedHeight;
         if (!height) {
-          const dropdown = topNode.querySelector(':scope > .dropdown-menu');
           height = (dropdown ? dropdown.offsetHeight : topNode.offsetHeight) + 'px';
           topNode.dataset.computedHeight = height;
         }
         menuBackdrop.style.height = height;
       }
 
-      function whenExited(topNode) { // I might not need topNode here, but leave for now
-        menuBackdrop.style.height = "0px";
+      function showDropdown(topNode) {
+        clearTimeout(closeTimer);
+        clearTimeout(switchTimer);
+        const prev = committedTopNode;
+        committedTopNode = topNode;
+        if (prev && prev !== topNode) {
+          hideDropdown(prev);
+          switchTimer = setTimeout(function () { revealDropdown(topNode); }, SWITCH_DELAY);
+        } else {
+          revealDropdown(topNode);
+        }
       }
+
+      function hideDropdown(topNode) {
+        const dropdown = topNode.querySelector(':scope > .dropdown-menu');
+        if (!dropdown) { return; }
+        dropdown.style.opacity = '';
+        dropdown.style.transform = '';
+        setTimeout(function () { dropdown.style.visibility = ''; }, 200);
+      }
+
+      function closeMenu() {
+        if (committedTopNode) {
+          hideDropdown(committedTopNode);
+          committedTopNode = null;
+        }
+        menuBackdrop.style.height = '0px';
+      }
+
       once('cp_theme_d10_hover', '#cp_theme_d10_menu .top-node').forEach(function (el) {
-
-        el.addEventListener('mouseover', function (event) {
-          whenEntered(el);
-        });
-        el.addEventListener('focusin', function (event) {
-          whenEntered(el);
+        el.addEventListener('mouseenter', function () {
+          clearTimeout(closeTimer);
+          dwellTimer = setTimeout(function () { showDropdown(el); }, DWELL_TIME);
         });
 
-        el.addEventListener('mouseleave', function (event) {
-          whenExited(el);
+        el.addEventListener('mouseleave', function () {
+          clearTimeout(dwellTimer);
+          closeTimer = setTimeout(closeMenu, CLOSE_GRACE);
         });
+
+        el.addEventListener('focusin', function () {
+          clearTimeout(dwellTimer);
+          clearTimeout(closeTimer);
+          showDropdown(el);
+        });
+
         el.addEventListener('focusout', function (event) {
-          if (!el.contains(event.relatedTarget)) {
-            whenExited(el);
+          if (!el.contains(event.relatedTarget) && committedTopNode === el) {
+            closeMenu();
           }
         });
       });

--- a/themes/cp_theme_d10/js/global.js
+++ b/themes/cp_theme_d10/js/global.js
@@ -80,6 +80,12 @@
         menuBackdrop.style.height = '0px';
       }
 
+      window.addEventListener('resize', function () {
+        if (committedTopNode) {
+          revealDropdown(committedTopNode);
+        }
+      });
+
       once('cp_theme_d10_hover', '#cp_theme_d10_menu .top-node').forEach(function (el) {
         el.addEventListener('mouseenter', function () {
           if (window.innerWidth < 992) {

--- a/themes/cp_theme_d10/js/global.js
+++ b/themes/cp_theme_d10/js/global.js
@@ -26,6 +26,38 @@
           }
         });
       });
+      const menuBackdrop = document.querySelector(".menu-backdrop");
+      function whenEntered(topNode) {
+        let height = topNode.dataset.computedHeight;
+        if (!height) {
+          const dropdown = topNode.querySelector(':scope > .dropdown-menu');
+          height = (dropdown ? dropdown.offsetHeight : topNode.offsetHeight) + 'px';
+          topNode.dataset.computedHeight = height;
+        }
+        menuBackdrop.style.height = height;
+      }
+
+      function whenExited(topNode) { // I might not need topNode here, but leave for now
+        menuBackdrop.style.height = "0px";
+      }
+      once('cp_theme_d10_hover', '#cp_theme_d10_menu .top-node').forEach(function (el) {
+
+        el.addEventListener('mouseover', function (event) {
+          whenEntered(el);
+        });
+        el.addEventListener('focusin', function (event) {
+          whenEntered(el);
+        });
+
+        el.addEventListener('mouseleave', function (event) {
+          whenExited(el);
+        });
+        el.addEventListener('focusout', function (event) {
+          if (!el.contains(event.relatedTarget)) {
+            whenExited(el);
+          }
+        });
+      });
       once('cp_theme_d10', '#cp_theme_d10_menu').forEach(function (el) {
         el.addEventListener('mouseout', function (event) {
           if (event.target === document.activeElement) {

--- a/themes/cp_theme_d10/js/global.js
+++ b/themes/cp_theme_d10/js/global.js
@@ -11,13 +11,17 @@
       once('cp_theme_d10', '#cp_theme_d10_menu .top-node .drop-down-toggle').forEach(function (el) {
         el.addEventListener('click', function (event) {
           let target = el.closest(".top-node");
-          target.classList.toggle("open");
+          if (window.innerWidth < 992) {
+            target.classList.toggle("open");
+          }
           event.preventDefault();
         });
         el.addEventListener('keyup', function (event) {
           if(event.key === "Enter") {
             let target = el.closest(".top-node");
-            target.classList.toggle("open");
+            if (window.innerWidth < 992) {
+              target.classList.toggle("open");
+            }
             event.preventDefault();
           }
         });

--- a/themes/cp_theme_d10/js/global.js
+++ b/themes/cp_theme_d10/js/global.js
@@ -27,7 +27,9 @@
         });
       });
       const menuBackdrop = document.querySelector(".menu-backdrop");
-      if (!menuBackdrop) { return; }
+      if (!menuBackdrop) {
+        return;
+      }
 
       let committedTopNode = null;
       let dwellTimer = null;
@@ -45,11 +47,7 @@
           dropdown.style.opacity = '1';
           dropdown.style.transform = 'translateY(0)';
         }
-        let height = topNode.dataset.computedHeight;
-        if (!height) {
-          height = (dropdown ? dropdown.offsetHeight : topNode.offsetHeight) + 'px';
-          topNode.dataset.computedHeight = height;
-        }
+        const height = (dropdown ? dropdown.offsetHeight : topNode.offsetHeight) + 'px';
         menuBackdrop.style.height = height;
       }
 
@@ -84,23 +82,36 @@
 
       once('cp_theme_d10_hover', '#cp_theme_d10_menu .top-node').forEach(function (el) {
         el.addEventListener('mouseenter', function () {
+          if (window.innerWidth < 992) {
+            return;
+          }
           clearTimeout(closeTimer);
           dwellTimer = setTimeout(function () { showDropdown(el); }, DWELL_TIME);
         });
 
         el.addEventListener('mouseleave', function () {
+          if (window.innerWidth < 992) {
+            return;
+          }
           clearTimeout(dwellTimer);
           closeTimer = setTimeout(closeMenu, CLOSE_GRACE);
         });
 
         el.addEventListener('focusin', function () {
+          if (window.innerWidth < 992) {
+            return;
+          }
           clearTimeout(dwellTimer);
           clearTimeout(closeTimer);
           showDropdown(el);
         });
 
         el.addEventListener('focusout', function (event) {
-          if (!el.contains(event.relatedTarget) && committedTopNode === el) {
+          if (window.innerWidth < 992) {
+            return;
+          }
+          const nextTopNode = event.relatedTarget && event.relatedTarget.closest('#cp_theme_d10_menu .top-node');
+          if (!el.contains(event.relatedTarget) && committedTopNode === el && !nextTopNode) {
             closeMenu();
           }
         });

--- a/themes/cp_theme_d10/templates/block/block--local-tasks-block.html.twig
+++ b/themes/cp_theme_d10/templates/block/block--local-tasks-block.html.twig
@@ -6,7 +6,7 @@
 #}
 {% block content %}
   {% if content %}
-    <nav class="tabs mt-2" role="navigation" aria-label="{{ 'Tabs'|t }}">
+    <nav class="tabs m-auto mt-2" role="navigation" aria-label="{{ 'Tabs'|t }}">
       {{ content }}
     </nav>
   {% endif %}

--- a/themes/cp_theme_d10/templates/block/block--local-tasks-block.html.twig
+++ b/themes/cp_theme_d10/templates/block/block--local-tasks-block.html.twig
@@ -1,0 +1,13 @@
+{# extends @bootstrap/layout/block.html.twig
+/**
+ * @file
+ * Theme override for tabs.
+ */
+#}
+{% block content %}
+  {% if content %}
+    <nav class="tabs mt-2" role="navigation" aria-label="{{ 'Tabs'|t }}">
+      {{ content }}
+    </nav>
+  {% endif %}
+{% endblock %}

--- a/themes/cp_theme_d10/templates/navigation/menu--main.html.twig
+++ b/themes/cp_theme_d10/templates/navigation/menu--main.html.twig
@@ -56,7 +56,7 @@
 			<div id="cp_theme_d10_menu" class="layout-container">
 			<div{{ attributes.removeClass('clearfix').addClass('nav navbar-nav justify-content-center px-4')|without('id') }}>
 		{% elseif menu_level == 1 %}
-			<div class="dropdown-menu pt-3 pb-4 border rounded-0 justify-content-between">
+			<div class="dropdown-menu pt-3 pb-4 rounded-0 justify-content-between">
 		{% endif %}
 		{% for item in items %}
 			{% set item_classes = [

--- a/themes/cp_theme_d10/templates/navigation/menu--main.html.twig
+++ b/themes/cp_theme_d10/templates/navigation/menu--main.html.twig
@@ -114,7 +114,7 @@
 		{% endfor %}
 		{% if menu_level == 0 %}
 			</div> {# .navbar-nav #}
-			<div class="menu-backdrop"></div>
+			<div class="menu-backdrop" style="height: 0px;"></div>
 			</div> {# #cp_theme_d10_menu #}
 		{% elseif menu_level <= 1 %}
 			</div> {# .dropdown-menu #}

--- a/themes/cp_theme_d10/templates/navigation/menu--main.html.twig
+++ b/themes/cp_theme_d10/templates/navigation/menu--main.html.twig
@@ -114,11 +114,10 @@
 		{% endfor %}
 		{% if menu_level == 0 %}
 			</div> {# .navbar-nav #}
+			<div class="menu-backdrop"></div>
 			</div> {# #cp_theme_d10_menu #}
 		{% elseif menu_level <= 1 %}
 			</div> {# .dropdown-menu #}
-		{% endif %}
-		{% if menu_level == 0 %}
 		{% endif %}
 	{% endif %}
 {% endmacro %}


### PR DESCRIPTION
Various fixes and improvements to the appearance of the new theme.

- Improve consistency of width on some internal pages
- Add `margin-top` to admin tabs, ensuring they are the width of the content
- Disable toggling of menu open/close when not in mobile menu -- previously one could click on the menu headings and toggle the state of the mobile menu when in wide screen view, which is not ideal
- Add box shadow on the dropdown menu
- Add menu hover delay and transition using separate menu backdrop element (new version of https://github.com/ICOS-Carbon-Portal/drupal/pull/18)