### PR TITLE
[cp_data_products] Add collection ID filtering

### DIFF
--- a/modules/custom/cp_data_products/config/install/core.entity_form_display.block_content.data_product_preview.default.yml
+++ b/modules/custom/cp_data_products/config/install/core.entity_form_display.block_content.data_product_preview.default.yml
@@ -29,30 +29,45 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
-  field_display_height:
-    weight: 30
+  field_use_collection:
+    weight: 28
     settings:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
-  field_number_of_columns:
+  field_collection_id:
     weight: 29
-    settings:
-      placeholder: ''
-    third_party_settings: {  }
-    type: number
-    region: content
-  field_parameter:
-    weight: 28
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
     region: content
+  field_parameter:
+    weight: 31
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_number_of_columns:
+    weight: 32
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
+    region: content
+  field_display_height:
+    weight: 33
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_keyword:
-    weight: 27
+    weight: 34
     settings:
       size: 60
       placeholder: ''
@@ -60,22 +75,7 @@ content:
     type: string_textfield
     region: content
   field_show_deprecated:
-    weight: 26
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
-  field_use_collection:
-    weight: 31
-    settings:
-      display_label: true
-    third_party_settings: {  }
-    type: boolean_checkbox
-    region: content
-  field_collection_id:
-    weight: 32
+    weight: 35
     settings:
       size: 60
       placeholder: ''

--- a/modules/custom/cp_data_products/config/install/core.entity_form_display.block_content.data_product_preview.default.yml
+++ b/modules/custom/cp_data_products/config/install/core.entity_form_display.block_content.data_product_preview.default.yml
@@ -9,6 +9,8 @@ dependencies:
     - field.field.block_content.data_product_preview.field_parameter
     - field.field.block_content.data_product_preview.field_keyword
     - field.field.block_content.data_product_preview.field_show_deprecated
+    - field.field.block_content.data_product_preview.field_use_collection
+    - field.field.block_content.data_product_preview.field_collection_id
   module:
     - link
   enforced:
@@ -59,6 +61,21 @@ content:
     region: content
   field_show_deprecated:
     weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_use_collection:
+    weight: 31
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_collection_id:
+    weight: 32
     settings:
       size: 60
       placeholder: ''

--- a/modules/custom/cp_data_products/config/install/core.entity_view_display.block_content.data_product_preview.default.yml
+++ b/modules/custom/cp_data_products/config/install/core.entity_view_display.block_content.data_product_preview.default.yml
@@ -9,6 +9,8 @@ dependencies:
     - field.field.block_content.data_product_preview.field_parameter
     - field.field.block_content.data_product_preview.field_keyword
     - field.field.block_content.data_product_preview.field_show_deprecated
+    - field.field.block_content.data_product_preview.field_use_collection
+    - field.field.block_content.data_product_preview.field_collection_id
   module:
     - link
   enforced:
@@ -68,6 +70,24 @@ content:
     region: content
   field_show_deprecated:
     weight: 0
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_use_collection:
+    weight: -1
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+  field_collection_id:
+    weight: -2
     label: above
     settings:
       link_to_entity: false

--- a/modules/custom/cp_data_products/config/install/field.field.block_content.data_product_preview.field_collection_id.yml
+++ b/modules/custom/cp_data_products/config/install/field.field.block_content.data_product_preview.field_collection_id.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.data_product_preview
+    - field.storage.block_content.field_collection_id
+  enforced:
+    module:
+      - cp_data_products
+id: block_content.data_product_preview.field_collection_id
+field_name: field_collection_id
+entity_type: block_content
+bundle: data_product_preview
+label: 'Collection ID'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/custom/cp_data_products/config/install/field.field.block_content.data_product_preview.field_use_collection.yml
+++ b/modules/custom/cp_data_products/config/install/field.field.block_content.data_product_preview.field_use_collection.yml
@@ -8,7 +8,7 @@ id: block_content.data_product_preview.field_use_collection
 field_name: field_use_collection
 entity_type: block_content
 bundle: data_product_preview
-label: 'Use collection ID'
+label: 'Use collection ID instead of data type'
 description: ''
 required: false
 translatable: false

--- a/modules/custom/cp_data_products/config/install/field.field.block_content.data_product_preview.field_use_collection.yml
+++ b/modules/custom/cp_data_products/config/install/field.field.block_content.data_product_preview.field_use_collection.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.data_product_preview
+    - field.storage.block_content.field_use_collection
+id: block_content.data_product_preview.field_use_collection
+field_name: field_use_collection
+entity_type: block_content
+bundle: data_product_preview
+label: 'Use collection ID'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/custom/cp_data_products/config/install/field.storage.block_content.field_collection_id.yml
+++ b/modules/custom/cp_data_products/config/install/field.storage.block_content.field_collection_id.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+  enforced:
+    module:
+      - cp_data_products
+id: block_content.field_collection_id
+field_name: field_collection_id
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/cp_data_products/config/install/field.storage.block_content.field_use_collection.yml
+++ b/modules/custom/cp_data_products/config/install/field.storage.block_content.field_use_collection.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_use_collection
+field_name: field_use_collection
+entity_type: block_content
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/cp_data_products/cp_data_products.install
+++ b/modules/custom/cp_data_products/cp_data_products.install
@@ -34,3 +34,76 @@ function cp_data_products_update_8001() {
 		FieldConfig::create($yml)->save();
 	}
 }
+
+/**
+ * Add use_collection and collection_id fields to data_product_preview block.
+ */
+function cp_data_products_update_8002() {
+
+	$module_path = \Drupal::service('extension.list.module')->getPath('cp_data_products');
+
+	$yml = Yaml::decode(file_get_contents($module_path . '/config/install/field.storage.block_content.field_use_collection.yml'));
+	if (!FieldStorageConfig::loadByName($yml['entity_type'], $yml['field_name'])) {
+		FieldStorageConfig::create($yml)->save();
+	}
+	$yml = Yaml::decode(file_get_contents($module_path . '/config/install/field.storage.block_content.field_collection_id.yml'));
+	if (!FieldStorageConfig::loadByName($yml['entity_type'], $yml['field_name'])) {
+		FieldStorageConfig::create($yml)->save();
+	}
+	$yml = Yaml::decode(file_get_contents($module_path . '/config/install/field.field.block_content.data_product_preview.field_use_collection.yml'));
+	if (!FieldConfig::loadByName($yml['entity_type'], $yml['bundle'], $yml['field_name'])) {
+		FieldConfig::create($yml)->save();
+	}
+	$yml = Yaml::decode(file_get_contents($module_path . '/config/install/field.field.block_content.data_product_preview.field_collection_id.yml'));
+	if (!FieldConfig::loadByName($yml['entity_type'], $yml['bundle'], $yml['field_name'])) {
+		FieldConfig::create($yml)->save();
+	}
+
+	$form_display = \Drupal::entityTypeManager()
+		->getStorage('entity_form_display')
+		->load('block_content.data_product_preview.default');
+	if ($form_display) {
+		$form_display->setComponent('field_use_collection', [
+			'weight' => 31,
+			'settings' => ['display_label' => TRUE],
+			'third_party_settings' => [],
+			'type' => 'boolean_checkbox',
+			'region' => 'content',
+		]);
+		$form_display->setComponent('field_collection_id', [
+			'weight' => 32,
+			'settings' => ['size' => 60, 'placeholder' => ''],
+			'third_party_settings' => [],
+			'type' => 'string_textfield',
+			'region' => 'content',
+		]);
+		$form_display->save();
+	}
+
+	$view_display = \Drupal::entityTypeManager()
+		->getStorage('entity_view_display')
+		->load('block_content.data_product_preview.default');
+	if ($view_display) {
+		$view_display->setComponent('field_use_collection', [
+			'weight' => -1,
+			'label' => 'above',
+			'settings' => [
+				'format' => 'default',
+				'format_custom_false' => '',
+				'format_custom_true' => '',
+			],
+			'third_party_settings' => [],
+			'type' => 'boolean',
+			'region' => 'content',
+		]);
+		$view_display->setComponent('field_collection_id', [
+			'weight' => -2,
+			'label' => 'above',
+			'settings' => ['link_to_entity' => FALSE],
+			'third_party_settings' => [],
+			'type' => 'string',
+			'region' => 'content',
+		]);
+		$view_display->save();
+	}
+}

--- a/modules/custom/cp_data_products/cp_data_products.install
+++ b/modules/custom/cp_data_products/cp_data_products.install
@@ -59,24 +59,45 @@ function cp_data_products_update_8002() {
 		FieldConfig::create($yml)->save();
 	}
 
+	$field_config = FieldConfig::loadByName('block_content', 'data_product_preview', 'field_use_collection');
+	if ($field_config) {
+		$field_config->setLabel('Use collection ID instead of data type');
+		$field_config->save();
+	}
+
 	$form_display = \Drupal::entityTypeManager()
 		->getStorage('entity_form_display')
 		->load('block_content.data_product_preview.default');
 	if ($form_display) {
 		$form_display->setComponent('field_use_collection', [
-			'weight' => 31,
+			'weight' => 28,
 			'settings' => ['display_label' => TRUE],
 			'third_party_settings' => [],
 			'type' => 'boolean_checkbox',
 			'region' => 'content',
 		]);
 		$form_display->setComponent('field_collection_id', [
-			'weight' => 32,
+			'weight' => 29,
 			'settings' => ['size' => 60, 'placeholder' => ''],
 			'third_party_settings' => [],
 			'type' => 'string_textfield',
 			'region' => 'content',
 		]);
+		$weights = [
+			'field_preview_type'      => 30,
+			'field_parameter'         => 31,
+			'field_number_of_columns' => 32,
+			'field_display_height'    => 33,
+			'field_keyword'           => 34,
+			'field_show_deprecated'   => 35,
+		];
+		foreach ($weights as $field_name => $weight) {
+			$component = $form_display->getComponent($field_name);
+			if ($component) {
+				$component['weight'] = $weight;
+				$form_display->setComponent($field_name, $component);
+			}
+		}
 		$form_display->save();
 	}
 

--- a/modules/custom/cp_data_products/cp_data_products.module
+++ b/modules/custom/cp_data_products/cp_data_products.module
@@ -10,13 +10,17 @@ function cp_data_products_preprocess_block(&$vars) {
     $field_preview_type = $vars['elements']['content']['field_preview_type'];
     $field_keyword = $vars['elements']['content']['field_keyword'];
     $field_show_deprecated = $vars['elements']['content']['field_show_deprecated'];
+    $field_use_collection = $vars['elements']['content']['field_use_collection'];
+    $field_collection_id = $vars['elements']['content']['field_collection_id'];
     $vars['#attached']['drupalSettings']['data_product_preview'][$param] = [
       'spec' => $vars['elements']['content']['field_data_type'][0]['#title'],
       'previewType' => isset($field_preview_type) && !empty($field_preview_type[0]) ? $field_preview_type[0]['#markup'] : '',
       'param' => explode(',', $param),
       'shouldGetHeight' => $vars['elements']['content']['field_display_height'][0]['#markup'] == "On" ? true : false,
       'keyword' => !empty($field_keyword[0]) ? $field_keyword[0]['#context']['value'] : '',
-      'showDeprecated' => !empty($field_show_deprecated[0]) && $field_show_deprecated[0]['#markup'] == "On" ? true : false
+      'showDeprecated' => !empty($field_show_deprecated[0]) && $field_show_deprecated[0]['#markup'] == "On" ? true : false,
+      'useCollection' => !empty($field_use_collection[0]) && $field_use_collection[0]['#markup'] == "On" ? true : false,
+      'collectionId' => !empty($field_collection_id[0]) ? $field_collection_id[0]['#context']['value'] : '',
     ];
   }
 }

--- a/modules/custom/cp_data_products/js/product-page.js
+++ b/modules/custom/cp_data_products/js/product-page.js
@@ -41,7 +41,7 @@
 	const query = (spec, shouldGetHeight, keyword, showDeprecated) => {
 		const samplingHeight = shouldGetHeight ? 'OPTIONAL{?dobj cpmeta:wasAcquiredBy/cpmeta:hasSamplingHeight ?samplingHeight} .' : '';
 		const filterNextVersion = showDeprecated ? '' : 'FILTER NOT EXISTS {[] cpmeta:isNextVersionOf ?dobj}';
-		const hasKeyword = keyword ? '?dobj cpmeta:hasKeyword "Drought 2018"^^xsd:string' : '';
+		const hasKeyword = keyword ? `?dobj cpmeta:hasKeyword "${keyword}"^^xsd:string` : '';
 
 		return `prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 		prefix cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
@@ -51,10 +51,31 @@
 			?dobj cpmeta:hasObjectSpec <${spec}> .
 			${filterNextVersion}
 			filter exists {?dobj cpmeta:wasSubmittedBy/prov:endedAtTime []}
-			?dobj cpmeta:wasAcquiredBy [prov:startedAtTime ?start ; prov:endedAtTime ?end] .
+			?dobj cpmeta:wasAcquiredBy/prov:startedAtTime ?start .
+			?dobj cpmeta:wasAcquiredBy/prov:endedAtTime ?end .
 			?dobj cpmeta:wasAcquiredBy/prov:wasAssociatedWith/cpmeta:hasName ?station .
 			${samplingHeight}
 			${hasKeyword}
+		}
+		order by ?station ${shouldGetHeight ? '?samplingHeight' : ''} ?start`;
+	}
+
+	const collectionQuery = (collectionId, shouldGetHeight) => {
+		const samplingHeight = shouldGetHeight ? 'OPTIONAL{?dobj cpmeta:wasAcquiredBy/cpmeta:hasSamplingHeight ?samplingHeight} .' : '';
+
+		return `prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+		prefix cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
+		prefix prov: <http://www.w3.org/ns/prov#>
+		prefix dcterms: <http://purl.org/dc/terms/>
+		select ?dobj ?station ?samplingHeight ?start ?end
+		where {
+			VALUES ?coll { <https://meta.icos-cp.eu/collections/${collectionId}> }
+			?coll dcterms:hasPart+ ?dobj .
+			filter exists {?dobj cpmeta:wasSubmittedBy/prov:endedAtTime []}
+			?dobj cpmeta:wasAcquiredBy/prov:startedAtTime ?start .
+			?dobj cpmeta:wasAcquiredBy/prov:endedAtTime ?end .
+			?dobj cpmeta:wasAcquiredBy/prov:wasAssociatedWith/cpmeta:hasName ?station .
+			${samplingHeight}
 		}
 		order by ?station ${shouldGetHeight ? '?samplingHeight' : ''} ?start`;
 	}
@@ -64,6 +85,9 @@
 	}
 
 	const displayPreviewTable = (tableConfig) => {
+		const sparqlQuery = tableConfig.useCollection
+			? collectionQuery(tableConfig.collectionId, tableConfig.shouldGetHeight)
+			: query(tableConfig.spec, tableConfig.shouldGetHeight, tableConfig.keyword, tableConfig.showDeprecated);
 		$.ajax({
 			method: 'post',
 			url: 'https://meta.icos-cp.eu/sparql',
@@ -72,7 +96,7 @@
 				'Content-Type': 'text/plain',
 				'Cache-Control': 'max-age=1000000'
 			},
-			data: query(tableConfig.spec, tableConfig.shouldGetHeight, tableConfig.keyword, tableConfig.showDeprecated)
+			data: sparqlQuery
 		}).done(function(result) {
 			let station = '';
 			let rowNumber = 1;


### PR DESCRIPTION
Adds collection ID filtering, with an override to use collection ID over data type if desired.

Fixes a few miscellaneous bugs and adds a couple optimizations to avoid query time-outs, will do a self-review shortly to annotate those.